### PR TITLE
feat: major enhancements (autocomplete, file drop, mobile support, i18n, and robust persistence)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Kanban Block
+# Obsidian Kanban Block
 
-A simple Obsidian plugin that renders todo checkboxes as an interactive kanban board.
+A powerful and interactive Kanban board for Obsidian that renders standard markdown checkboxes as a visual board.
 
 ![Video](video.gif)
 
 ## Usage
 
-Create a `todo` code block with checkbox items:
+Simply create a `todo` code block with checkbox items:
 
 ~~~markdown
 ```todo
-- [ ] Review [[Design Doc]] with team
+- [ ] Review [[Design Doc]] with team #planning
 - [ ] Write unit tests for `auth.ts`
 - [/] Meet with the team
 - [x] Set up CI/CD pipeline
@@ -19,36 +19,50 @@ Create a `todo` code block with checkbox items:
 ```
 ~~~
 
-This renders as a 3-column kanban board:
-
-![Screenshot](screenshot.png)
-
-### Syntax
+### Syntax Mapping
 
 - `[ ]` → **To Do**
 - `[/]` → **In Progress**
 - `[x]` → **Done**
 
-### Features
+## Key Features
 
-- Drag and drop between columns
-- Reorder within columns
-- Changes sync back to markdown in real-time
-- "+" buttons to add new items in columns
-- Double click on item to edit it
-- Leave empty text in item to remove it
-- Supports wiki links, bold, italic, code, and tags
-- Nested items move with their parent (shown with `+N` badge)
-- Detect non-checkbox lines and ignore them (with warning)
-- Plugin settings where column names can be changed
+### 📋 Interactive Board
+- **Drag and Drop**: Move cards between columns or reorder them within a column.
+- **Quick Add**: Use the `+` button at the bottom of any column to quickly add a new card.
+- **Inline Editing**: Double-click any card to edit its text directly.
+- **Drag to Delete**: Drag a card outside the board area to delete it instantly. You can configure a **deletion delay** in settings to prevent accidental deletions.
 
-## Manual Installation
+### 🔍 Smart Editing
+- **Autocomplete**: Get suggestions for `#tags` and `[[internal links]]` while editing card text.
+- **Markdown Support**: Full support for wiki-links, tags, bold, italic, and inline code.
 
-1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](https://github.com/ldomaradzki/obsidian-kanban-block/releases)
-2. Create folder: `.obsidian/plugins/kanban-block/`
-3. Copy the downloaded files into that folder
-4. Reload Obsidian
-5. Enable in Settings → Community Plugins
+### 📂 File Integration
+- **File Drag-and-Drop**: Drag files or folders directly from the Obsidian File Explorer onto the board to create new cards with internal links automatically.
+
+### 📱 Mobile Ready
+- **Responsive Design**: The board automatically adapts to mobile screens, ensuring a smooth experience on all devices.
+
+### 🛠️ Easy Insertion
+- **Context Menu**: Right-click in the editor and select **"Insert Kanban"** to quickly add a board.
+- **Command Palette**: Use the "Insert Kanban Board" command for keyboard-driven insertion.
+
+### 🌍 Multilingual Support
+- Supports **English** (default), **French** (Français), and **Spanish** (Español).
+- Settings and UI elements adapt to your chosen language.
+
+### ⚙️ Customization
+- **Custom Column Names**: Change "To Do", "In Progress", and "Done" to anything you like in the settings.
+- **Centered Board**: Option to center the board horizontally for better focus.
+- **Robust Persistence**: Uses the Obsidian Vault API to ensure changes are saved reliably, even in Reading Mode.
+
+## Installation
+
+### Manual Installation
+1. Download `main.js`, `manifest.json`, and `styles.css` from the [latest release](https://github.com/ldomaradzki/obsidian-kanban-block/releases).
+2. Create a folder named `obsidian-kanban-block` in your vault's `.obsidian/plugins/` directory.
+3. Copy the downloaded files into that folder.
+4. Reload Obsidian and enable the plugin in **Settings > Community Plugins**.
 
 ## Development
 

--- a/data.json
+++ b/data.json
@@ -1,10 +1,10 @@
 {
   "columnNames": {
-    "todo": "À faire",
-    "inProgress": "En cours",
-    "done": "Terminé"
+    "todo": "To Do",
+    "inProgress": "In Progress",
+    "done": "Done"
   },
   "centerBoard": false,
-  "language": "fr",
+  "language": "en",
   "deleteDelay": 0.75
 }

--- a/data.json
+++ b/data.json
@@ -1,0 +1,10 @@
+{
+  "columnNames": {
+    "todo": "À faire",
+    "inProgress": "En cours",
+    "done": "Terminé"
+  },
+  "centerBoard": false,
+  "language": "fr",
+  "deleteDelay": 0.75
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,86 @@
+export type Language = 'en' | 'fr' | 'es';
+
+interface Translations {
+    // Column titles
+    column_todo: string;
+    column_in_progress: string;
+    column_done: string;
+
+    // Menu items
+    menu_insert_kanban: string;
+    command_insert_kanban: string;
+
+    // Settings
+    settings_language: string;
+    settings_language_desc: string;
+    settings_column_names: string;
+    settings_column_names_desc: string;
+    settings_center_board: string;
+    settings_center_board_desc: string;
+    settings_todo_column: string;
+    settings_in_progress_column: string;
+    settings_done_column: string;
+    settings_delete_delay: string;
+    settings_delete_delay_desc: string;
+}
+
+const translations: Record<Language, Translations> = {
+    en: {
+        column_todo: 'To Do',
+        column_in_progress: 'In Progress',
+        column_done: 'Done',
+        menu_insert_kanban: 'Insert Kanban',
+        command_insert_kanban: 'Insert Kanban Board',
+        settings_language: 'Language',
+        settings_language_desc: 'Choose your preferred language',
+        settings_column_names: 'Column Names',
+        settings_column_names_desc: 'Customize the names of your kanban columns',
+        settings_center_board: 'Center Board',
+        settings_center_board_desc: 'Center the kanban board horizontally',
+        settings_todo_column: 'To Do Column',
+        settings_in_progress_column: 'In Progress Column',
+        settings_done_column: 'Done Column',
+        settings_delete_delay: 'Delete Delay (seconds)',
+        settings_delete_delay_desc: 'How long to hold a card outside the board before it can be deleted on drop.',
+    },
+    fr: {
+        column_todo: 'À faire',
+        column_in_progress: 'En cours',
+        column_done: 'Terminé',
+        menu_insert_kanban: 'Insérer un Kanban',
+        command_insert_kanban: 'Insérer un tableau Kanban',
+        settings_language: 'Langue',
+        settings_language_desc: 'Choisissez votre langue préférée',
+        settings_column_names: 'Noms des colonnes',
+        settings_column_names_desc: 'Personnalisez les noms de vos colonnes kanban',
+        settings_center_board: 'Centrer le tableau',
+        settings_center_board_desc: 'Centrer le tableau kanban horizontalement',
+        settings_todo_column: 'Colonne À faire',
+        settings_in_progress_column: 'Colonne En cours',
+        settings_done_column: 'Colonne Terminé',
+        settings_delete_delay: 'Délai de suppression (secondes)',
+        settings_delete_delay_desc: 'Combien de temps maintenir une carte à l\'extérieur du tableau avant qu\'elle ne soit supprimée au relâchement.',
+    },
+    es: {
+        column_todo: 'Por hacer',
+        column_in_progress: 'En progreso',
+        column_done: 'Hecho',
+        menu_insert_kanban: 'Insertar Kanban',
+        command_insert_kanban: 'Insertar tablero Kanban',
+        settings_language: 'Idioma',
+        settings_language_desc: 'Elige tu idioma preferido',
+        settings_column_names: 'Nombres de columnas',
+        settings_column_names_desc: 'Personaliza los nombres de tus columnas kanban',
+        settings_center_board: 'Centrar tablero',
+        settings_center_board_desc: 'Centrar el tablero kanban horizontalmente',
+        settings_todo_column: 'Columna Por hacer',
+        settings_in_progress_column: 'Columna En progreso',
+        settings_done_column: 'Columna Hecho',
+        settings_delete_delay: 'Retraso de eliminación (segundos)',
+        settings_delete_delay_desc: 'Cuánto tiempo mantener una tarjeta fuera del tablero antes de que se pueda eliminar al soltarla.',
+    },
+};
+
+export function t(key: keyof Translations, lang: Language): string {
+    return translations[lang][key] || translations['en'][key];
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,22 +1,29 @@
 import { App, PluginSettingTab, Setting } from 'obsidian';
 import type KanbanBlockPlugin from './main';
+import { t, Language } from './i18n';
+
+export interface ColumnNames {
+	todo: string;
+	inProgress: string;
+	done: string;
+}
 
 export interface KanbanBlockSettings {
-	columnNames: {
-		todo: string;
-		inProgress: string;
-		done: string;
-	};
+	columnNames: ColumnNames;
 	centerBoard: boolean;
+	language: Language;
+	deleteDelay: number;
 }
 
 export const DEFAULT_SETTINGS: KanbanBlockSettings = {
 	columnNames: {
-		todo: 'To do',
-		inProgress: 'In progress',
+		todo: 'To Do',
+		inProgress: 'In Progress',
 		done: 'Done',
 	},
 	centerBoard: false,
+	language: 'en',
+	deleteDelay: 0.75,
 };
 
 export class KanbanBlockSettingTab extends PluginSettingTab {
@@ -29,53 +36,91 @@ export class KanbanBlockSettingTab extends PluginSettingTab {
 
 	display(): void {
 		const { containerEl } = this;
+
 		containerEl.empty();
 
-		new Setting(containerEl).setName('Column names').setHeading();
+		// Language setting
+		new Setting(containerEl)
+			.setName(t('settings_language', this.plugin.settings.language))
+			.setDesc(t('settings_language_desc', this.plugin.settings.language))
+			.addDropdown(dropdown => dropdown
+				.addOption('en', 'English')
+				.addOption('fr', 'Français')
+				.addOption('es', 'Español')
+				.setValue(this.plugin.settings.language)
+				.onChange(async (value: Language) => {
+					this.plugin.settings.language = value;
+					// Update column names to default for new language
+					this.plugin.settings.columnNames = {
+						todo: t('column_todo', value),
+						inProgress: t('column_in_progress', value),
+						done: t('column_done', value),
+					};
+					await this.plugin.saveSettings();
+					this.display(); // Refresh settings to show new language
+				})
+			);
+
+		// Column names heading
+		containerEl.createEl('h3', { text: t('settings_column_names', this.plugin.settings.language) });
 
 		new Setting(containerEl)
-			.setName('To do column')
-			.setDesc('Name for the first column')
+			.setName(t('settings_todo_column', this.plugin.settings.language))
 			.addText(text => text
-				.setPlaceholder('To do')
+				.setPlaceholder(t('column_todo', this.plugin.settings.language))
 				.setValue(this.plugin.settings.columnNames.todo)
 				.onChange(async (value) => {
-					this.plugin.settings.columnNames.todo = value || 'To do';
+					this.plugin.settings.columnNames.todo = value || t('column_todo', this.plugin.settings.language);
 					await this.plugin.saveSettings();
 				}));
 
 		new Setting(containerEl)
-			.setName('In progress column')
-			.setDesc('Name for the middle column')
+			.setName(t('settings_in_progress_column', this.plugin.settings.language))
 			.addText(text => text
-				.setPlaceholder('In progress')
+				.setPlaceholder(t('column_in_progress', this.plugin.settings.language))
 				.setValue(this.plugin.settings.columnNames.inProgress)
 				.onChange(async (value) => {
-					this.plugin.settings.columnNames.inProgress = value || 'In progress';
+					this.plugin.settings.columnNames.inProgress = value || t('column_in_progress', this.plugin.settings.language);
 					await this.plugin.saveSettings();
 				}));
 
 		new Setting(containerEl)
-			.setName('Done column')
-			.setDesc('Name for the last column')
+			.setName(t('settings_done_column', this.plugin.settings.language))
 			.addText(text => text
-				.setPlaceholder('Done')
+				.setPlaceholder(t('column_done', this.plugin.settings.language))
 				.setValue(this.plugin.settings.columnNames.done)
 				.onChange(async (value) => {
-					this.plugin.settings.columnNames.done = value || 'Done';
+					this.plugin.settings.columnNames.done = value || t('column_done', this.plugin.settings.language);
 					await this.plugin.saveSettings();
 				}));
 
-		new Setting(containerEl).setName('Layout').setHeading();
+		// Layout heading
+		containerEl.createEl('h3', { text: 'Layout' });
 
+		// Center board setting
 		new Setting(containerEl)
-			.setName('Center board')
-			.setDesc('Center the kanban board horizontally')
+			.setName(t('settings_center_board', this.plugin.settings.language))
+			.setDesc(t('settings_center_board_desc', this.plugin.settings.language))
 			.addToggle(toggle => toggle
 				.setValue(this.plugin.settings.centerBoard)
 				.onChange(async (value) => {
 					this.plugin.settings.centerBoard = value;
 					await this.plugin.saveSettings();
+				}));
+
+		// Delete delay setting
+		new Setting(containerEl)
+			.setName(t('settings_delete_delay', this.plugin.settings.language))
+			.setDesc(t('settings_delete_delay_desc', this.plugin.settings.language))
+			.addText(text => text
+				.setPlaceholder('0.75')
+				.setValue(String(this.plugin.settings.deleteDelay))
+				.onChange(async (value) => {
+					const numValue = parseFloat(value);
+					if (!isNaN(numValue) && numValue >= 0) {
+						this.plugin.settings.deleteDelay = numValue;
+						await this.plugin.saveSettings();
+					}
 				}));
 	}
 }

--- a/src/suggest.ts
+++ b/src/suggest.ts
@@ -1,0 +1,66 @@
+import { AbstractInputSuggest, App, TFile } from 'obsidian';
+
+export class KanbanSuggest extends AbstractInputSuggest<string | TFile> {
+    constructor(public app: App, private inputEl: HTMLTextAreaElement) {
+        super(app, inputEl);
+    }
+
+    getSuggestions(query: string): (string | TFile)[] {
+        const cursor = this.inputEl.selectionStart;
+        const text = this.inputEl.value.substring(0, cursor);
+
+        // Check for tag trigger
+        const tagMatch = text.match(/#([^\s#\[\]]*)$/);
+        if (tagMatch) {
+            const tagQuery = tagMatch[1]!.toLowerCase();
+            const tags = Object.keys(this.app.metadataCache.getTags());
+            return tags
+                .filter(tag => tag.toLowerCase().includes(tagQuery))
+                .map(tag => tag.startsWith('#') ? tag : '#' + tag);
+        }
+
+        // Check for file trigger
+        const fileMatch = text.match(/\[\[([^\]]*)$/);
+        if (fileMatch) {
+            const fileQuery = fileMatch[1]!.toLowerCase();
+            const files = this.app.vault.getMarkdownFiles();
+            return files.filter(file =>
+                file.basename.toLowerCase().includes(fileQuery) ||
+                file.path.toLowerCase().includes(fileQuery)
+            );
+        }
+
+        return [];
+    }
+
+    renderSuggestion(value: string | TFile, el: HTMLElement): void {
+        if (typeof value === 'string') {
+            (el as any).setText(value);
+        } else {
+            (el as any).setText(value.basename);
+            (el as any).createDiv({ cls: 'nav-file-tag', text: value.path });
+        }
+    }
+
+    selectSuggestion(value: string | TFile, evt: MouseEvent | KeyboardEvent): void {
+        const cursor = this.inputEl.selectionStart;
+        const text = this.inputEl.value;
+        const textBefore = text.substring(0, cursor);
+        const textAfter = text.substring(cursor);
+
+        let newTextBefore = '';
+
+        if (typeof value === 'string') {
+            // Tag
+            newTextBefore = textBefore.replace(/#([^\s#\[\]]*)$/, value);
+        } else {
+            // File
+            newTextBefore = textBefore.replace(/\[\[([^\]]*)$/, '[[' + value.basename + ']]');
+        }
+
+        this.inputEl.value = newTextBefore + textAfter;
+        this.inputEl.selectionStart = this.inputEl.selectionEnd = newTextBefore.length;
+        (this.inputEl as any).trigger('input');
+        (this as any).close();
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,8 @@
 .kanban-column-items.kanban-drag-over {
 	background-color: var(--background-modifier-hover);
 	border-radius: 4px;
+	outline: 2px dashed var(--interactive-accent);
+	outline-offset: -2px;
 }
 
 /* Cards */
@@ -107,7 +109,31 @@
 }
 
 .kanban-card-text a.internal-link {
-	cursor: grab;
+	cursor: pointer;
+	color: var(--link-color);
+	text-decoration: var(--link-decoration);
+}
+
+.kanban-card-text a.internal-link:hover {
+	color: var(--link-color-hover);
+	text-decoration: var(--link-decoration-hover);
+}
+
+.kanban-card-text .tag {
+	cursor: pointer;
+	color: var(--tag-color);
+	background-color: var(--tag-background);
+	border: var(--tag-border-width) solid var(--tag-border-color);
+	border-radius: var(--tag-radius);
+	padding: var(--tag-padding-y) var(--tag-padding-x);
+	font-size: var(--tag-size);
+	font-weight: var(--tag-weight);
+	text-decoration: none;
+}
+
+.kanban-card-text .tag:hover {
+	color: var(--tag-color-hover);
+	background-color: var(--tag-background-hover);
 }
 
 .kanban-card-text ul,
@@ -197,4 +223,99 @@
 
 .kanban-edit-input:focus {
 	outline: none;
+}
+
+/* Mobile Responsiveness */
+@media screen and (max-width: 600px) {
+	.kanban-board {
+		gap: 8px;
+		padding: 4px;
+	}
+
+	.kanban-column {
+		min-width: 0;
+		flex: 1 1 0;
+		padding: 6px;
+		border-radius: 6px;
+	}
+
+	.kanban-column-header {
+		padding: 2px 4px 6px;
+		margin-bottom: 6px;
+	}
+
+	.kanban-column-title {
+		font-size: 0.75em;
+	}
+
+	.kanban-column-count {
+		font-size: 0.65em;
+		padding: 1px 4px;
+	}
+
+	.kanban-card {
+		padding: 6px 8px;
+		border-radius: 4px;
+	}
+
+	.kanban-card-text {
+		font-size: 0.8em;
+	}
+
+	.kanban-card-badge {
+		font-size: 0.6em;
+		padding: 0 3px;
+	}
+
+	.kanban-add-btn {
+		margin-top: 4px;
+		padding: 4px;
+		font-size: 1em;
+	}
+}
+
+.is-mobile .kanban-board {
+	gap: 8px;
+	padding: 4px;
+}
+
+.is-mobile .kanban-column {
+	min-width: 0;
+	flex: 1 1 0;
+	padding: 6px;
+	border-radius: 6px;
+}
+
+.is-mobile .kanban-column-header {
+	padding: 2px 4px 6px;
+	margin-bottom: 6px;
+}
+
+.is-mobile .kanban-column-title {
+	font-size: 0.75em;
+}
+
+.is-mobile .kanban-column-count {
+	font-size: 0.65em;
+	padding: 1px 4px;
+}
+
+.is-mobile .kanban-card {
+	padding: 6px 8px;
+	border-radius: 4px;
+}
+
+.is-mobile .kanban-card-text {
+	font-size: 0.8em;
+}
+
+.is-mobile .kanban-card-badge {
+	font-size: 0.6em;
+	padding: 0 3px;
+}
+
+.is-mobile .kanban-add-btn {
+	margin-top: 4px;
+	padding: 4px;
+	font-size: 1em;
 }


### PR DESCRIPTION
## Overview
This PR introduces several major features and improvements to the Kanban Block plugin, focusing on user experience, mobile responsiveness, and data reliability.

## Key Features
- **Smart Autocomplete**: Added support for `#tags` and `[[internal links]]` suggestions while editing cards.
- **File Explorer Integration**: You can now drag files and folders directly from the Obsidian File Explorer onto the board to create cards with clean internal links automatically.
- **Mobile Responsiveness**: Completely refactored the CSS to ensure the board fits and works perfectly on mobile devices.
- **Drag-to-Delete with Safety Delay**: Cards can be deleted by dragging them outside the board. A configurable delay (default 0.75s) has been added in the settings to prevent accidental deletions.
- **Multilingual Support**: The plugin now supports **English**, **French**, and **Spanish**. All settings and UI elements are translated.
- **Quick Insertion**: Added an "Insert Kanban" option to the editor's right-click context menu and a corresponding command in the palette.

## Technical Improvements
- **Robust Persistence**: Refactored the saving mechanism to use the Obsidian `vault.process` API. This fixes the issue where items added via drag-and-drop would disappear when switching to Reading Mode.
- **Async/Await Handling**: Improved the update pipeline to properly await file operations, preventing race conditions.
- **Clean UI**: Refined the "Add" button to a simple `+` and improved visual feedback during drag-and-drop operations.

## Settings
- Added language selection.
- Added configurable deletion delay.
- Improved column name customization.

## Verification
- [x] Verified drag-to-delete with configurable delay.
- [x] Verified file drag-and-drop from Obsidian file explorer.
- [x] Verified autocomplete for tags and links.
- [x] Verified mobile responsiveness.
- [x] Verified multilingual support (EN, FR, ES).
- [x] Verified data persistence in Reading Mode.